### PR TITLE
Custom labels

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -26,28 +26,32 @@
         </p>
 
         <p>
-          <px-alert-label type="important"></px-alert-label><span>Drink your beer!</span>
+          <px-alert-label type="important" label="Important"></px-alert-label><span>Drink your beer!</span>
         </p>
         <p>
         </p>
-          <px-alert-label type="Warning"></px-alert-label><span>The Martians are coming.</span>
+          <px-alert-label type="Warning" label="Warning"></px-alert-label><span>The Martians are coming.</span>
         <p>
-          <px-alert-label type="Error"></px-alert-label><span>Doh!  You pushed the wrong button.</span>
+          <px-alert-label type="Error" label="Error"></px-alert-label><span>Doh!  You pushed the wrong button.</span>
         </p>
         <p>
-          <px-alert-label type="info"></px-alert-label><span>Paris is nice in the Spring.</span>
+          <px-alert-label type="info" label="Information"></px-alert-label><span>Paris is nice in the Spring.</span>
         </p>
         <p>
-          <px-alert-label type="healthy"></px-alert-label><span>Spinach</span>
+          <px-alert-label type="healthy" label="Healthy"></px-alert-label><span>Spinach</span>
         </p>
         <p>
-          <px-alert-label type="healthy-inverted"></px-alert-label><span>Carrot</span>
+          <px-alert-label type="healthy-inverted" label="Inverted"></px-alert-label><span>Carrot</span>
         </p>
         <p>
-          <px-alert-label type="unknown"></px-alert-label><span>Spooky</span>
+          <px-alert-label type="unknown" label="Unknown"></px-alert-label><span>Spooky</span>
         </p>
         <p>
           <px-alert-label type="I"></px-alert-label><span>Purposedly use an invalid alert label type</span>
+        </p>
+        <p>
+        <p>
+          <px-alert-label type="important" label="3"></px-alert-label><span>Can also be used for badges!</span>
         </p>
     </body>
 </html>

--- a/px-alert-label.html
+++ b/px-alert-label.html
@@ -40,42 +40,11 @@ Element renders an alert label from a predefined set of alerts.
      */
     properties: {
       type: String,
-      label: {
-        type: String,
-        computed: 'computeLabel(type)'
-      },
+      label: String,
       alertStyle: {
         type: String,
         reflect: true,
         computed: 'computeAlertStyle(type)'
-      }
-    },
-
-    /**
-     * calculate the computed property value
-     *
-     * @method increment
-     */
-    computeLabel: function(type) {
-      // TODO: validation on "type"
-      switch (type.toLowerCase()) {
-        // handle localization here
-        case 'important':
-          return 'Important';
-        case 'warning':
-          return 'Warning';
-        case 'error':
-          return 'Error';
-        case 'info':
-          return 'Information';
-        case 'healthy':
-        case 'healthy-inverted':
-          return 'Healthy';
-        case 'unknown':
-          return 'Unknown';
-        default:
-          console.log('px-alert-label error: unrecognized type: ' + type);
-          return '';
       }
     },
 

--- a/test/fixture.html
+++ b/test/fixture.html
@@ -27,13 +27,14 @@
 <body>
 
 <!-- You use the document as a place to set up your fixtures. -->
-<p><px-alert-label type="important"></px-alert-label></p>
-<p><px-alert-label type="warning"></px-alert-label></p>
-<p><px-alert-label type="error"></px-alert-label></p>
-<p><px-alert-label type="info"></px-alert-label></p>
-<p><px-alert-label type="healthy"></px-alert-label></p>
-<p><px-alert-label type="healthy-inverted"></px-alert-label></p>
-<p><px-alert-label type="unknown"></px-alert-label></p>
+<p><px-alert-label type="important" label="Important"></px-alert-label></p>
+<p><px-alert-label type="warning" label="Warning"></px-alert-label></p>
+<p><px-alert-label type="error" label="Error"></px-alert-label></p>
+<p><px-alert-label type="info" label="Information"></px-alert-label></p>
+<p><px-alert-label type="healthy" label="Healthy"></px-alert-label></p>
+<p><px-alert-label type="healthy-inverted" label="Inverted"></px-alert-label></p>
+<p><px-alert-label type="unknown" label="Unknown"></px-alert-label></p>
+<p><px-alert-label type="important" label="3"></px-alert-label></p>
 
 </body>
 </html>

--- a/test/wct-tests.html
+++ b/test/wct-tests.html
@@ -11,13 +11,14 @@
 <body>
 
 <!-- You use the document as a place to set up your fixtures. -->
-<px-alert-label type="important" id="fixture-important"></px-alert-label>
-<px-alert-label type="warning" id="fixture-warning"></px-alert-label>
-<px-alert-label type="error" id="fixture-error"></px-alert-label>
-<px-alert-label type="info" id="fixture-info"></px-alert-label>
-<px-alert-label type="healthy" id="fixture-healthy"></px-alert-label>
-<px-alert-label type="healthy-inverted" id="fixture-healthy-inverted"></px-alert-label>
-<px-alert-label type="unknown" id="fixture-unknown"></px-alert-label>
+<px-alert-label type="important" label="Important" id="fixture-important"></px-alert-label>
+<px-alert-label type="warning" label="Warning" id="fixture-warning"></px-alert-label>
+<px-alert-label type="error" label="Error" id="fixture-error"></px-alert-label>
+<px-alert-label type="info" label="Information" id="fixture-info"></px-alert-label>
+<px-alert-label type="healthy" label="Healthy" id="fixture-healthy"></px-alert-label>
+<px-alert-label type="healthy-inverted" label="Inverted" id="fixture-healthy-inverted"></px-alert-label>
+<px-alert-label type="unknown" label="Unknown" id="fixture-unknown"></px-alert-label>
+<px-alert-label type="important" label="3" id="fixture-badge"></px-alert-label>
 <script>
   suite('<px-alert-label>', function() {
     test('is px-alert-label', function() {
@@ -26,8 +27,9 @@
       assert.equal(document.getElementById('fixture-error').label, 'Error');
       assert.equal(document.getElementById('fixture-info').label, 'Information');
       assert.equal(document.getElementById('fixture-healthy').label, 'Healthy');
-      assert.equal(document.getElementById('fixture-healthy-inverted').label, 'Healthy');
+      assert.equal(document.getElementById('fixture-healthy-inverted').label, 'Inverted');
       assert.equal(document.getElementById('fixture-unknown').label, 'Unknown');
+      assert.equal(document.getElementById('fixture-badge').label, '3');
     });
   });
 </script>


### PR DESCRIPTION
# Pull Request

#### A description of the changes proposed in the pull request:
I think it's strange that alert-label was hardcoded so that only the limited set of label strings could be used. I removed the computed label and made it configurable instead. This would be a breaking change since the label attribute has to be specified or else they'll all be blank.

#### A reference to a related issue (if applicable):
[Rally Story] (https://rally1.rallydev.com/#/33932457711d/detail/userstory/56296801730)

#### @mentions of the person or team responsible for reviewing proposed changes:
@mdwragg 

#### Working Tests:
Tests are passing in WCT
